### PR TITLE
Updates swap based on ls-1231

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,7 @@ node_modules
 /dist
 /docs
 /src
-
+/dist/src
 .env
 # local env files
 .env.local

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pontem/liquidswap-widget",
-  "version": "0.2.12",
+  "version": "0.3.0",
   "homepage": "https://github.com/pontem-network/liquidswap-widget#readme",
   "description": "LiquidSwap widget as custom web component",
   "files": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@metamask/jazzicon": "2.0.0",
     "@pontem/aptos-wallet-adapter": "0.7.2",
-    "@pontem/coins-registry": "2.1.8",
+    "@pontem/coins-registry": "2.1.19",
     "@pontem/liquidswap-sdk": "0.6.1",
     "@tsconfig/recommended": "1.0.2",
     "@types/lodash": "4.14.182",

--- a/src/Swap/SwapContainer.vue
+++ b/src/Swap/SwapContainer.vue
@@ -41,19 +41,20 @@
           <SwapInput mode="to" />
         </div>
         <div
-            v-if="tokensChosen && !fullCurveOfDefaultPool"
-            class="swap__row"
-            :class="[mainStore.insideNativeWallet.value && 'swap__row--extra-padding']">
+          v-if="tokensChosen && !fullCurveOfDefaultPool"
+          class="swap__row"
+          :class="[mainStore.insideNativeWallet.value && 'swap__row--extra-padding']"
+        >
           <PInlineMessage class="mt-1" :class="'curve-warning'" severity="warn"
-            >Caution: make sure the pair you are trading should be stable or
-            uncorrelated. i.e USDC/USDT is stable and USDC/BTC is
-            uncorrelated</PInlineMessage
+            >Caution: make sure the pair you are trading should be stable or uncorrelated. i.e USDC/USDT
+            is stable and USDC/BTC is uncorrelated</PInlineMessage
           >
         </div>
         <div
-            v-show="tokensChosen && !fullCurveOfDefaultPool"
-            class="swap__row"
-            :class="[mainStore.insideNativeWallet.value && 'swap__row--extra-padding']">
+          v-show="tokensChosen && !fullCurveOfDefaultPool"
+          class="swap__row"
+          :class="[mainStore.insideNativeWallet.value && 'swap__row--extra-padding']"
+        >
           <CurveSwitch />
         </div>
         <div
@@ -68,19 +69,14 @@
           <SwapInfo />
         </div>
         <div v-if="fullCurveOfDefaultPool" class="swap__row">
-          <CurveInfo :type="fullCurveOfDefaultPool" :version="version"/>
+          <CurveInfo :type="fullCurveOfDefaultPool" :version="version" />
         </div>
         <div v-show="canSwitchContract" class="swap__row -version">
           <ContractSwitch type="swap" />
         </div>
         <ReservesContainer type="swap" />
         <div class="swap__row">
-          <p-button
-            v-if="!connected"
-            type="submit"
-            tabindex="5"
-            class="swap__button is-connect"
-          >
+          <p-button v-if="!connected" type="submit" tabindex="5" class="swap__button is-connect">
             <span>Connect Wallet</span>
           </p-button>
           <p-button
@@ -96,14 +92,12 @@
         </div>
       </form>
       <div class="full_version">
-        <h4 class="full_version__header">
-          More features in full-size version
-        </h4>
+        <h4 class="full_version__header">More features in full-size version</h4>
         <p class="full_version__description">
           Go to the web dApp to add liquidity or stake LP tokens in farms
         </p>
         <a class="full_version__link" href="https://liquidswap.com" target="_blank">
-          <img class="full_version__img" src="./../assets/expand.svg">
+          <img class="full_version__img" src="./../assets/expand.svg" />
           <span>liquidswap.com</span>
         </a>
       </div>
@@ -115,7 +109,7 @@
       :to-token="swapStore.toCurrency.token"
       :from-token="swapStore.fromCurrency.token"
     />
-    <PriceImpactWarningDialog/>
+    <PriceImpactWarningDialog />
   </div>
 </template>
 
@@ -131,7 +125,7 @@ import { ReservesContainer } from '@/components/ReservesContainer';
 import { TxSettingsDialog } from '@/components/TxSettingsDialog';
 import { ContractSwitch } from '@/components/ContractSwitch';
 import { useCurrentAccountBalance } from '@/composables/useAccountBalance';
-import { useStore, useSwapStore, useTokensStore, usePoolsStore } from '@/store';
+import { useStore, useSwapStore, usePoolsStore } from '@/store';
 import { d } from '@/utils/utils';
 import SwapInfo from './SwapInfo.vue';
 import SwapInput from './SwapInput.vue';
@@ -141,19 +135,18 @@ import {
   VERSION_0,
   VERSION_0_5,
   CURVE_UNCORRELATED_V05,
-  CURVE_UNCORRELATED
+  CURVE_UNCORRELATED,
 } from '@/constants/constants';
 import { getCurve, getShortCurveFromFull } from '@/utils/contracts';
-import { TVersionType } from "@/types";
+import { TCurveType, TVersionType } from '@/types';
+import { IPersistedPool } from '@/types/pools';
 
 const mainStore = useStore();
 const poolsStore = usePoolsStore();
 const swapStore = useSwapStore();
-const tokensStore = useTokensStore();
 
 const { account } = mainStore;
 const version = computed(() => swapStore.version);
-const insideNativeWallet = computed(() => mainStore.insideNativeWallet.value);
 
 const stableCurve = computed(() => getCurve('stable', version.value));
 const unstableCurve = computed(() => getCurve('uncorrelated', version.value));
@@ -175,46 +168,43 @@ const curveType = computed(() =>
 const fullCurveOfDefaultPool = computed(() => {
   // Now all known pools have version 0
   const isExistsDefaultPoolV0 = poolsStore.getCurveType(
-      swapStore.fromCurrency?.token,
-      swapStore.toCurrency?.token,
-      VERSION_0,
+    swapStore.fromCurrency?.token,
+    swapStore.toCurrency?.token,
+    VERSION_0,
   );
 
   const isExistsDefaultPoolV05 = poolsStore.getCurveType(
-      swapStore.fromCurrency?.token,
-      swapStore.toCurrency?.token,
-      VERSION_0_5,
+    swapStore.fromCurrency?.token,
+    swapStore.toCurrency?.token,
+    VERSION_0_5,
   );
 
   const hasDefaultPoolStableCurveV0 = [CURVE_STABLE, CURVE_STABLE_V05].includes(
-      '' + isExistsDefaultPoolV0,
+    '' + isExistsDefaultPoolV0,
   );
 
-  const hasDefaultPoolStableCurveV05 = [
-    CURVE_STABLE,
-    CURVE_STABLE_V05,
-  ].includes('' + isExistsDefaultPoolV05);
+  const hasDefaultPoolStableCurveV05 = [CURVE_STABLE, CURVE_STABLE_V05].includes(
+    '' + isExistsDefaultPoolV05,
+  );
 
-  const hasDefaultPoolUncorrelatedCurveV0 = [
-    CURVE_UNCORRELATED,
-    CURVE_UNCORRELATED_V05,
-  ].includes('' + isExistsDefaultPoolV0);
+  const hasDefaultPoolUncorrelatedCurveV0 = [CURVE_UNCORRELATED, CURVE_UNCORRELATED_V05].includes(
+    '' + isExistsDefaultPoolV0,
+  );
 
-  const hasDefaultPoolUncorrelatedCurveV05 = [
-    CURVE_UNCORRELATED,
-    CURVE_UNCORRELATED_V05,
-  ].includes('' + isExistsDefaultPoolV05);
+  const hasDefaultPoolUncorrelatedCurveV05 = [CURVE_UNCORRELATED, CURVE_UNCORRELATED_V05].includes(
+    '' + isExistsDefaultPoolV05,
+  );
 
   if (
-      (isExistsDefaultPoolV0 || isExistsDefaultPoolV05) &&
-      (hasDefaultPoolStableCurveV0 || hasDefaultPoolStableCurveV05)
+    (isExistsDefaultPoolV0 || isExistsDefaultPoolV05) &&
+    (hasDefaultPoolStableCurveV0 || hasDefaultPoolStableCurveV05)
   ) {
     return version.value === VERSION_0_5 ? CURVE_STABLE_V05 : CURVE_STABLE;
   }
 
   if (
-      (isExistsDefaultPoolV0 || isExistsDefaultPoolV05) &&
-      (hasDefaultPoolUncorrelatedCurveV0 || hasDefaultPoolUncorrelatedCurveV05)
+    (isExistsDefaultPoolV0 || isExistsDefaultPoolV05) &&
+    (hasDefaultPoolUncorrelatedCurveV0 || hasDefaultPoolUncorrelatedCurveV05)
   ) {
     return version.value === VERSION_0_5 ? CURVE_UNCORRELATED_V05 : CURVE_UNCORRELATED;
   }
@@ -223,41 +213,74 @@ const fullCurveOfDefaultPool = computed(() => {
 });
 
 watch([curveType, stableCurve, unstableCurve], () => {
-    if (curveType.value) {
-      swapStore.curve =
-          curveType.value === stableCurve.value || curveType.value === 'stable'
-          ? stableCurve.value
-          : unstableCurve.value;
-    }
-    else {
-      const shortName = getShortCurveFromFull(swapStore.curve);
-      swapStore.curve = getCurve(shortName, version.value);
-    }
-  },
-)
+  if (curveType.value) {
+    swapStore.curve =
+      curveType.value === stableCurve.value || curveType.value === 'stable'
+        ? stableCurve.value
+        : unstableCurve.value;
+  } else {
+    const shortName = getShortCurveFromFull(swapStore.curve);
+    swapStore.curve = getCurve(shortName, version.value);
+  }
+});
 
-const fromBalance = useCurrentAccountBalance(
-  computed(() => swapStore.fromCurrency?.token),
+watch(
+  () => [swapStore.fromCurrency.token, swapStore.toCurrency.token],
+  async ([newFrom, newTo], [oldFrom, oldTo]) => {
+    if (!newFrom || !newTo) return;
+
+    // If the pair of tokens is the same, we don't need to set the curve
+    if (oldFrom === newTo && oldTo == newFrom) {
+      return;
+    }
+
+    // need to reset the version when changing a pair of tokens
+    swapStore.version = VERSION_0;
+
+    let resultCurve: string | undefined;
+    let resultVersion: number = VERSION_0;
+    let resultPool: IPersistedPool | undefined;
+
+    for (const curveType of ['stable', 'unstable'] as TCurveType[]) {
+      for (const version of [VERSION_0_5, VERSION_0]) {
+        const curve = getCurve(curveType, version);
+        const pool = await poolsStore.getPool(newFrom, newTo, curve, version);
+
+        if (
+          !resultPool ||
+          ((pool?.reserveX ?? 0) > resultPool.reserveX && (pool?.reserveY ?? 0) > resultPool.reserveY)
+        ) {
+          resultPool = pool;
+          resultCurve = curve;
+          resultVersion = version;
+        }
+      }
+    }
+
+    /**
+     * Set uncorrelated pool version 0 as the default value.
+     * In this case, the user chooses the curve and version himself.
+     */
+    swapStore.curve = resultCurve;
+    swapStore.version = resultVersion;
+  },
 );
-const toBalance = useCurrentAccountBalance(
-  computed(() => swapStore.toCurrency?.token),
-);
+
+const fromBalance = useCurrentAccountBalance(computed(() => swapStore.fromCurrency?.token));
+const toBalance = useCurrentAccountBalance(computed(() => swapStore.toCurrency?.token));
 const txSettingsDialog = ref();
 const overlayAnchor = ref();
 
-const tokensChosen = computed(
-  () => !!swapStore.fromCurrency.token && !!swapStore.toCurrency.token,
-);
+const tokensChosen = computed(() => !!swapStore.fromCurrency.token && !!swapStore.toCurrency.token);
 const canSwitchContract = computed(() => {
   const isToTokenChosen = swapStore.toCurrency?.token;
 
   const isDefaultPool = !!fullCurveOfDefaultPool.value;
   const hasDefaultPoolStableCurve = [CURVE_STABLE_V05, CURVE_STABLE].includes(
-      '' + fullCurveOfDefaultPool.value,
+    '' + fullCurveOfDefaultPool.value,
   );
   const isPoolUnknown = fullCurveOfDefaultPool.value === false;
-  const canSwitch =
-      (isDefaultPool && hasDefaultPoolStableCurve) || isPoolUnknown;
+  const canSwitch = (isDefaultPool && hasDefaultPoolStableCurve) || isPoolUnknown;
 
   return isToTokenChosen && canSwitch;
 });
@@ -304,10 +327,7 @@ const buttonState = computed(() => {
     };
   }
 
-  if (
-    !toBalance.isExists.value &&
-    !(toBalance.isFetching.value && toBalance.isFirstFetching.value)
-  ) {
+  if (!toBalance.isExists.value && !(toBalance.isFetching.value && toBalance.isFirstFetching.value)) {
     return {
       disabled: false,
       text: `Register ${toBalance.symbol.value} and Swap`,
@@ -322,18 +342,16 @@ const buttonState = computed(() => {
 
 const priceImpactClass = computed(() => {
   return swapStore.priceImpactState === 'normal'
-      ? 'p-button-primary'
-      : swapStore.priceImpactState === 'warning'
-          ? 'p-button-warning_custom'
-          : 'p-button-alert';
+    ? 'p-button-primary'
+    : swapStore.priceImpactState === 'warning'
+    ? 'p-button-warning_custom'
+    : 'p-button-alert';
 });
 
 function submitForm(e: Event) {
   const isNextButton = (e.target as HTMLElement)?.enterKeyHint === 'next';
   const isSubmitDisabled = buttonState.value.disabled;
-  const cancelEvent = Boolean(
-    (isNextButton || isSubmitDisabled) && connected.value,
-  );
+  const cancelEvent = Boolean((isNextButton || isSubmitDisabled) && connected.value);
   if (cancelEvent) return;
 
   const handler = !connected.value ? onConnectWallet : showSwapDialog;
@@ -350,8 +368,7 @@ function toggleSwap() {
 
 function showSwapDialog() {
   const isShowSwapWarningDialog =
-      swapStore.priceImpactState === 'warning' ||
-      swapStore.priceImpactState === 'alert';
+    swapStore.priceImpactState === 'warning' || swapStore.priceImpactState === 'alert';
 
   if (isShowSwapWarningDialog) {
     mainStore.showDialog('priceImpact');

--- a/src/Swap/SwapInfo.vue
+++ b/src/Swap/SwapInfo.vue
@@ -110,7 +110,7 @@ const slippageAmount = computed(() => swap.slippageAmount);
 const hasSlippage = computed(
     () =>
         (version.value === VERSION_0 &&
-            swap.curve === getCurve('uncorrelated', version.value)) ||
+            swap.curve === getCurve('unstable', version.value)) ||
         version.value === VERSION_0_5,
 );
 

--- a/src/components/ButtonToken/buttonToken.scss
+++ b/src/components/ButtonToken/buttonToken.scss
@@ -10,7 +10,7 @@
   color: white;
 
   &:hover {
-    background: linear-gradient(90deg, #015c68 0%, #04a57d 100%);
+    background: linear-gradient(90deg, #015c68 0%, #04a57d 100%) !important;
     color: white;
   }
 

--- a/src/components/ContractSwitch/ContractSwitch.vue
+++ b/src/components/ContractSwitch/ContractSwitch.vue
@@ -3,9 +3,9 @@
     <div class="list__pool-version-row">
       <span>Pool Version </span>
       <ToolTip
-          position="top"
-          :tooltipText="'V0.5 is the latest smart contract version - see docs for details.'"
-          class="tooltip-version-pools"
+        position="top"
+        :tooltipText="'V0.5 is the latest smart contract version - see docs for details.'"
+        class="tooltip-version-pools"
       >
         <i class="pi pi-info-circle info-circle" />
       </ToolTip>
@@ -14,9 +14,11 @@
         :options="poolVersionOptions"
         option-disabled="disabled"
         option-value="value"
+        data-tid="pool-version-switch-container"
         option-label="label"
         class="ml-auto no-a11y"
         :unselectable="false"
+        :disabled="!canSwitchVersion"
       >
         <template #option="slotProps">
           {{ slotProps.option.label }}
@@ -28,42 +30,104 @@
 
 <script lang="ts" setup>
 import { getCurve } from '@/utils/contracts';
-import {
-  usePoolsStore,
-  useSwapStore,
-} from '@/store';
-import { computed } from 'vue';
+import { useSwapStore } from '@/store';
+import { computed, watch } from 'vue';
 import ToolTip from '@/components/ToolTip/Tooltip.vue';
-import SelectButton from "primevue/selectbutton";
-import { VERSION_0, VERSION_0_5 } from "@/constants/constants";
-import { TVersionType } from "@/types";
+import SelectButton from 'primevue/selectbutton';
+import { usePoolExistence } from '@/composables/usePoolExistence';
 
-const poolsStore = usePoolsStore();
+interface IProps {
+  type: 'swap' | 'create' | 'add' | 'burn';
+}
+
+export type TCurveType = 'unstable' | 'stable';
 
 const store = useSwapStore();
 
-const version = computed(() => store.version);
+const props = defineProps<IProps>();
 
-const predefinedCurve = computed(() => {
-  return poolsStore.getCurveType(
-      store.fromCurrency.token,
-      store.toCurrency.token,
-      version.value as TVersionType,
-  );
-});
+const poolExistence = usePoolExistence();
+
+watch(
+  [() => store.fromCurrency.token, () => store.toCurrency.token, () => store.curve, () => store.version],
+  () => {
+    checkPoolExistence('stable', 0);
+    checkPoolExistence('unstable', 0);
+
+    checkPoolExistence('stable', 0.5);
+    checkPoolExistence('unstable', 0.5);
+  },
+);
 
 const poolVersionOptions = computed(() => {
-  const unstableCurve = getCurve('uncorrelated', version.value);
-  let disabled = false;
-  if (
-    store.curve === unstableCurve && predefinedCurve.value === unstableCurve
-  ) {
-    // and pool is default
-    disabled = true;
-  }
+  const isSwap = props.type === 'swap';
+
   return [
-    { id: 1, label: 'V0', value: VERSION_0 },
-    { id: 2, label: 'V0.5', value: VERSION_0_5, disabled },
+    { id: 1, label: 'V0', value: 0, disabled: isSwap && isV0PoolAbsent.value },
+    {
+      id: 2,
+      label: 'V0.5',
+      value: 0.5,
+      disabled: isSwap && isV05PoolAbsent.value,
+    },
   ];
 });
+
+const isStableV0PoolAbsent = computed(() => computeIsPoolAbsent('stable', 0));
+const isUnstableV0PoolAbsent = computed(() => computeIsPoolAbsent('unstable', 0));
+const isStableV05PoolAbsent = computed(() => computeIsPoolAbsent('stable', 0.5));
+const isUnstableV05PoolAbsent = computed(() => computeIsPoolAbsent('unstable', 0.5));
+const isStableCurveSelected = computed(
+  () => store.curve === getCurve('stable', 0.5) || store.curve === getCurve('stable', 0),
+);
+const isV0PoolAbsent = computed(() =>
+  isStableCurveSelected.value ? isStableV0PoolAbsent.value : isUnstableV0PoolAbsent.value,
+);
+const isV05PoolAbsent = computed(() =>
+  isStableCurveSelected.value ? isStableV05PoolAbsent.value : isUnstableV05PoolAbsent.value,
+);
+
+const canSwitchVersion = computed(() => props.type === 'swap');
+
+function computeIsPoolAbsent(curveType: TCurveType, version: number) {
+  const curve = getCurve(curveType, version);
+
+  return (
+    Boolean(store.fromCurrency.token) &&
+    Boolean(store.toCurrency.token) &&
+    !poolExistence.isFetching(
+      {
+        fromCoin: store.fromCurrency.token ?? '',
+        toCoin: store.toCurrency.token ?? '',
+        curve,
+      },
+      version,
+    ) &&
+    !poolExistence.poolExists(
+      {
+        fromCoin: store.fromCurrency.token ?? '',
+        toCoin: store.toCurrency.token ?? '',
+        curve,
+      },
+      version,
+    )
+  );
+}
+
+async function checkPoolExistence(curveType: TCurveType, version: number) {
+  const curve = getCurve(curveType, version);
+
+  if (!store.fromCurrency.token || !store.toCurrency.token || !store.curve) {
+    return;
+  }
+
+  await poolExistence.check(
+    {
+      fromCoin: store.fromCurrency.token,
+      toCoin: store.toCurrency.token,
+      curve,
+    },
+    version,
+  );
+}
 </script>

--- a/src/components/CurveSwitch/CurveSwitch.vue
+++ b/src/components/CurveSwitch/CurveSwitch.vue
@@ -3,15 +3,17 @@
     <div
       class="stable-switch-container__switch"
       :class="{
-        isSelected: store.curve === curveUncorrelated,
+        isSelected: store.curve === curveUnstable,
         busy: isBusy,
       }"
-      @click="switchSelected(curveUncorrelated)"
+      data-tid="curve-switch-uncorrelated"
+      :disabled="isUnstablePoolAbsent"
+      @click="!isUnstablePoolAbsent && switchSelected(curveUnstable)"
     >
       <img src="../../assets/curves/uncorrelated.svg" alt="uncorrelated curve" />
       <p>Uncorrelated</p>
       <ToolTip position="top" :tooltipText="'Using x*y=K formula'">
-        <i class="pi pi-info-circle" :style="{ paddingTop: '2px' }"/>
+        <i class="pi pi-info-circle" :style="{ paddingTop: '2px' }" />
       </ToolTip>
     </div>
 
@@ -20,8 +22,10 @@
         isSelected: store.curve === curveStable,
         busy: isBusy,
       }"
+      :disabled="isStablePoolAbsent"
       class="stable-switch-container__switch"
-      @click="switchSelected(curveStable)"
+      data-tid="curve-switch-stable"
+      @click="!isStablePoolAbsent && switchSelected(curveStable)"
     >
       <img
         :style="{ marginTop: '-2px', marginBottom: '2px' }"
@@ -30,7 +34,7 @@
       />
       <p>Stable</p>
       <ToolTip position="top-left" :tooltipText="'Using formula optimized for stable tokens swaps'">
-        <i class="pi pi-info-circle" :style="{ paddingTop: '2px'}"/>
+        <i class="pi pi-info-circle" :style="{ paddingTop: '2px' }" />
       </ToolTip>
     </div>
     <PToast position="top-right" group="tr" />
@@ -41,37 +45,40 @@ import { computed, watch } from 'vue';
 import { useToast } from 'primevue/usetoast';
 import PToast from 'primevue/toast';
 import ToolTip from '@/components/ToolTip/Tooltip.vue';
-import {
-  useSwapStore,
-  useTokensStore,
-} from '@/store';
+import { useSwapStore, useTokensStore } from '@/store';
 import { getCurve } from '@/utils/contracts';
+import { TCurveType } from '@/types';
+import { usePoolExistence } from '@/composables/usePoolExistence';
 
 const toast = useToast();
 
 const store = useSwapStore();
 const tokenStore = useTokensStore();
+const poolExistence = usePoolExistence();
+
+interface IProps {
+  curve?: string;
+  version?: number;
+}
+
+defineProps<IProps>();
 
 const version = computed(() => store.version);
 const curveStable = computed(() => getCurve('stable', version.value));
-const curveUncorrelated = computed(() => getCurve('uncorrelated', version.value));
+const curveUnstable = computed(() => getCurve('unstable', version.value));
+const isBusy = computed(() => (store.isBusy !== undefined ? store.isBusy.value : false));
 
-const isBusy = computed(() =>
-  store.isBusy !== undefined ? store.isBusy.value : false,
+const isStableV0PoolAbsent = computed(() => computeIsPoolAbsent('stable', 0));
+const isStableV05PoolAbsent = computed(() => computeIsPoolAbsent('stable', 0.5));
+const isStablePoolAbsent = computed(() => isStableV0PoolAbsent.value && isStableV05PoolAbsent.value);
+const isUnstableV0PoolAbsent = computed(() => computeIsPoolAbsent('unstable', 0));
+const isUnstableV05PoolAbsent = computed(() => computeIsPoolAbsent('unstable', 0.5));
+const isUnstablePoolAbsent = computed(
+  () => isUnstableV0PoolAbsent.value && isUnstableV05PoolAbsent.value,
 );
 
-const switchSelected = (curve: string) => {
-  if (isBusy.value === true) return;
-  store.curve = curve;
-};
-
 watch(
-  [
-    () => store.fromCurrency.token,
-    () => store.toCurrency.token,
-    () => store.curve,
-    () => store.version,
-  ],
+  [() => store.fromCurrency.token, () => store.toCurrency.token, () => store.curve, () => store.version],
   () => {
     if (
       store.curve === curveStable.value &&
@@ -88,7 +95,60 @@ watch(
         group: 'tr',
       });
     }
+
+    checkPoolExistence('stable', 0);
+    checkPoolExistence('stable', 0.5);
+
+    checkPoolExistence('unstable', 0);
+    checkPoolExistence('unstable', 0.5);
   },
   { deep: true },
 );
+
+function computeIsPoolAbsent(curveType: TCurveType, version: number) {
+  const curve = getCurve(curveType, version);
+
+  return (
+    Boolean(store.fromCurrency.token) &&
+    Boolean(store.toCurrency.token) &&
+    !poolExistence.isFetching(
+      {
+        fromCoin: store.fromCurrency.token ?? '',
+        toCoin: store.toCurrency.token ?? '',
+        curve,
+      },
+      version,
+    ) &&
+    !poolExistence.poolExists(
+      {
+        fromCoin: store.fromCurrency.token ?? '',
+        toCoin: store.toCurrency.token ?? '',
+        curve,
+      },
+      version,
+    )
+  );
+}
+
+async function checkPoolExistence(curveType: TCurveType, version: number) {
+  const curve = getCurve(curveType, version);
+
+  if (!store.fromCurrency.token || !store.toCurrency.token || !curve) {
+    return;
+  }
+
+  await poolExistence.check(
+    {
+      fromCoin: store.fromCurrency.token,
+      toCoin: store.toCurrency.token,
+      curve,
+    },
+    version,
+  );
+}
+
+const switchSelected = (curve: string) => {
+  if (isBusy.value === true) return;
+  store.curve = curve;
+};
 </script>

--- a/src/components/SwapConfirm/SwapInfo.vue
+++ b/src/components/SwapConfirm/SwapInfo.vue
@@ -78,7 +78,7 @@ const slippageAmount = computed(() => swapStore.slippageAmount);
 const hasSlippage = computed(
 () =>
     (version.value === VERSION_0 &&
-        swapStore.curve === getCurve('uncorrelated', version.value)) ||
+        swapStore.curve === getCurve('unstable', version.value)) ||
     version.value === VERSION_0_5,
 );
 

--- a/src/components/TxSettingsDialog/TxSettingsDialog.vue
+++ b/src/components/TxSettingsDialog/TxSettingsDialog.vue
@@ -133,7 +133,7 @@ const slippage = createSyncRef('modelValue');
 const hasSlippage = computed(
   () =>
       (version.value === VERSION_0 &&
-          swapStore.curve === getCurve('uncorrelated', version.value)) ||
+          swapStore.curve === getCurve('unstable', version.value)) ||
       version.value === VERSION_0_5,
 );
 

--- a/src/composables/usePoolExistence.ts
+++ b/src/composables/usePoolExistence.ts
@@ -1,66 +1,113 @@
-import { Ref, ref, watch } from 'vue';
+import { Ref, reactive, watch } from 'vue';
 
 import { ICreateToken, IPoolExist, TVersionType } from '@/types';
-import { useStore } from "@/store";
+import { useStore } from '@/store';
+import { VERSION_0, VERSION_0_5 } from '@/constants/constants';
 
 type CurveType = 'stable' | 'uncorrelated';
+
+interface IPoolExistence {
+  exists: boolean;
+  isFetching: boolean;
+}
+
+function getPoolExistenceKey(params: IPoolExist, contract?: number) {
+  return `${params.fromCoin}|${params.toCoin}|${params.curve}|${contract}`;
+}
+
+const poolExistenceMap = reactive<Record<string, IPoolExistence>>({});
 
 export function usePoolExistence() {
   const mainStore = useStore();
   const sdk = mainStore.sdk;
 
-  const poolExists = ref<boolean>(false);
-  const isFetching = ref<boolean>(false);
+  function getPoolExistenceEntity(params: IPoolExist, contract?: number) {
+    const poolExistenceKey = getPoolExistenceKey(params, contract);
 
-  async function checkExistence(params: IPoolExist): Promise<boolean> {
-    isFetching.value = true;
-    if (params.curve === undefined) {
-      throw new Error('Curve type is undefined');
+    return poolExistenceMap[poolExistenceKey] ?? {};
+  }
+
+  function poolExists(params: IPoolExist, contract?: number) {
+    return getPoolExistenceEntity(params, contract).exists;
+  }
+
+  function isFetching(params: IPoolExist, contract?: number) {
+    return getPoolExistenceEntity(params, contract).isFetching;
+  }
+
+  async function checkExistence(params: IPoolExist, contract?: number) {
+    const poolExistenceKey = getPoolExistenceKey(params, contract);
+
+    if (!poolExistenceMap[poolExistenceKey]) {
+      poolExistenceMap[poolExistenceKey] = {
+        exists: false,
+        isFetching: false,
+      };
     }
-    try {
-      const response = await sdk.value.Swap.getLiquidityPoolResource({
-        fromToken: params.fromCoin,
-        toToken: params.toCoin,
-        curveType: params.curve as CurveType,
-        version: params.version,
-      });
-      isFetching.value = false;
-      return !!response.liquidityPoolResource;
-    } catch (error) {
 
-      console.log('check Pool Existence error', error);
-      return false;
-    } finally {
-      isFetching.value = false;
+    poolExistenceMap[poolExistenceKey].isFetching = true;
+    const res = await sdk.value.Swap.getLiquidityPoolResource({
+      fromToken: params.fromCoin,
+      toToken: params.toCoin,
+      curveType: params.curve as CurveType,
+      version: contract == VERSION_0 ? VERSION_0 : VERSION_0_5,
+    });
+
+    console.log('usePoolExistance: checkExistence:res', res);
+
+    poolExistenceMap[poolExistenceKey].isFetching = false;
+    return !!res.liquidityPoolResource;
+  }
+
+  async function check(params: IPoolExist, contract?: number) {
+    const poolExistenceKey = getPoolExistenceKey(params, contract);
+
+    if (!poolExistenceMap[poolExistenceKey]) {
+      poolExistenceMap[poolExistenceKey] = {
+        exists: false,
+        isFetching: false,
+      };
     }
+    const res = await checkExistence(params, contract);
+    console.log('usePoolExistance: check:', poolExistenceMap, poolExistenceMap[poolExistenceKey], res);
+    poolExistenceMap[poolExistenceKey].exists = res;
   }
 
-  async function check(params: IPoolExist) {
-    poolExists.value = await checkExistence(params);
+  function reset(params: IPoolExist, contract?: number) {
+    const poolExistenceKey = getPoolExistenceKey(params, contract);
+
+    if (!poolExistenceMap[poolExistenceKey]) {
+      poolExistenceMap[poolExistenceKey] = {
+        exists: false,
+        isFetching: false,
+      };
+    }
+
+    poolExistenceMap[poolExistenceKey].exists = false;
   }
 
-  function reset() {
-    poolExists.value = false;
-  }
-
-  function watchChanges(
-    from: ICreateToken,
-    to: ICreateToken,
-    curve: Ref<CurveType>,
-    version: Ref<TVersionType>,
-  ) {
+  function watchChanges(from: ICreateToken, to: ICreateToken, curve: Ref<CurveType>, version: Ref<TVersionType>) {
     watch(
       [from.token, to.token, curve.value, version.value],
       async () => {
         if (!from.token || !to.token) {
-          reset();
+          reset(
+            {
+              fromCoin: from.token ?? '',
+              toCoin: to.token ?? '',
+              curve: curve.value,
+            },
+            version?.value,
+          );
         } else {
-          await check({
-            fromCoin: from.token,
-            toCoin: to.token,
-            curve: curve.value,
-            version: version.value
-          });
+          await check(
+            {
+              fromCoin: from.token,
+              toCoin: to.token,
+              curve: curve.value,
+            },
+            version.value,
+          );
         }
       },
       {
@@ -70,11 +117,8 @@ export function usePoolExistence() {
   }
 
   return {
-    // data
     isFetching,
     poolExists,
-
-    // methods
     check,
     watch: watchChanges,
     reset,

--- a/src/store/usePoolsStore.ts
+++ b/src/store/usePoolsStore.ts
@@ -196,7 +196,7 @@ export const usePoolsStore = defineStore('poolsStore', () => {
   const loadPool = async (pool: IPersistedPool) => {
     const { coinX, coinY, curve, contract } = pool;
     const curveStable = getCurve('stable', contract);
-    const curveType = curve === 'stable' || curve === curveStable ? curveStable : getCurve('uncorrelated', contract);
+    const curveType = curve === 'stable' || curve === curveStable ? curveStable : getCurve('unstable', contract);
 
     const liquidityPool = getPoolStr(coinX, coinY, curveType, contract);
     const lpCoinInfo = getPoolLpInfoStr(getPoolLpStr(coinX, coinY, curveType, contract));
@@ -213,7 +213,7 @@ export const usePoolsStore = defineStore('poolsStore', () => {
     const curveType = ['stable', 'uncorrelated'].includes(curve)
       ? curve === 'stable'
         ? getCurve('stable', contract)
-        : getCurve('uncorrelated', contract)
+        : getCurve('unstable', contract)
       : curve;
 
     const liquidityPool = getPoolStr(sortedX, sortedY, curveType, contract);
@@ -355,7 +355,7 @@ export const usePoolsStore = defineStore('poolsStore', () => {
     return predefinedCurves.stable.has(tokenPair)
       ? getCurve('stable', version)
       : predefinedCurves.uncorrelated.has(tokenPair)
-      ? getCurve('uncorrelated', version)
+      ? getCurve('unstable', version)
       : false;
   }
 

--- a/src/store/useSwapStore.ts
+++ b/src/store/useSwapStore.ts
@@ -38,7 +38,7 @@ export const useSwapStore = defineStore('swapStore', () => {
   const mainStore = useStore();
   const { sdk } = mainStore;
 
-  const curve = ref<string>();
+  const curve = ref<string>('stable');
 
   const stableSwapType = ref<'high' | 'normal'>('normal');
   const poolExistence = usePoolExistence();

--- a/src/store/useSwapStore.ts
+++ b/src/store/useSwapStore.ts
@@ -8,13 +8,12 @@ import { useStore } from '@/store/useStore';
 import { is_sorted, d, decimalsMultiplier } from '@/utils/utils';
 import { usePoolsStore, useTokensStore } from '@/store';
 import { getFromCache } from '@/utils/cache';
-import {DENOMINATOR, VERSION_0_5, VERSION_0, CURVE_STABLE, CURVE_STABLE_V05} from '@/constants/constants';
+import { DENOMINATOR, VERSION_0_5, VERSION_0 } from '@/constants/constants';
 import { usePoolExistence } from '@/composables/usePoolExistence';
 import { useContractVersion } from '@/composables/useContractVersion';
 import { IStoredToken, TVersionType } from '@/types';
 import { getCurve, getResourcesAccount, getShortCurveFromFull } from '@/utils/contracts';
-import { PontemWalletName } from "@pontem/aptos-wallet-adapter";
-
+import { PontemWalletName } from '@pontem/aptos-wallet-adapter';
 
 const DEFAULT_SLIPPAGE = 0.005;
 
@@ -31,7 +30,6 @@ export const useSwapStore = defineStore('swapStore', () => {
     amount: undefined,
     reserve: 0,
     usdEquivalent: undefined,
-
   });
 
   const { version } = useContractVersion();
@@ -40,7 +38,7 @@ export const useSwapStore = defineStore('swapStore', () => {
   const mainStore = useStore();
   const { sdk } = mainStore;
 
-  const curve = ref<string>(getCurve('uncorrelated', version.value));
+  const curve = ref<string>();
 
   const stableSwapType = ref<'high' | 'normal'>('normal');
   const poolExistence = usePoolExistence();
@@ -72,8 +70,7 @@ export const useSwapStore = defineStore('swapStore', () => {
   });
 
   watch([tokensStore.tokens], () => {
-    from.token =
-      tokensStore.getToken(from.token)?.type || mainStore.defaultToken.value;
+    from.token = tokensStore.getToken(from.token)?.type || mainStore.defaultToken.value;
     to.token =
       from.token !== tokensStore.getToken(to.token)?.type
         ? tokensStore.getToken(to.token)?.type
@@ -83,7 +80,7 @@ export const useSwapStore = defineStore('swapStore', () => {
   onMounted(() => resetState());
 
   function resetState() {
-    version.value = 0;
+    version.value = VERSION_0;
     from.token = mainStore.defaultToken.value;
     to.token = undefined;
     from.amount = undefined;
@@ -95,11 +92,7 @@ export const useSwapStore = defineStore('swapStore', () => {
     to.usdEquivalent = undefined;
   }
 
-  function convertToDecimals(
-    amt?: number,
-    fromToken?: string,
-    toToken?: string,
-  ) {
+  function convertToDecimals(amt?: number, fromToken?: string, toToken?: string) {
     if (!amt || !fromToken || !toToken) {
       return amt;
     }
@@ -129,7 +122,7 @@ export const useSwapStore = defineStore('swapStore', () => {
   }
 
   async function refetchRates(silent = false): Promise<void> {
-    if (from.token && to.token) {
+    if (from.token && to.token && curve.value) {
       lastInteractiveField.value = interactiveField.value;
       if (!silent) {
         isUpdatingRate.value = true;
@@ -137,9 +130,7 @@ export const useSwapStore = defineStore('swapStore', () => {
       const mode = lastInteractiveField.value;
 
       const isSorted = is_sorted(from.token, to.token);
-      const [fromToken, toToken] = isSorted
-        ? [from.token, to.token]
-        : [to.token, from.token];
+      const [fromToken, toToken] = isSorted ? [from.token, to.token] : [to.token, from.token];
 
       const resourceType = getPoolStr(fromToken, toToken, curve.value, version.value as TVersionType);
 
@@ -156,7 +147,6 @@ export const useSwapStore = defineStore('swapStore', () => {
         fee.value = response.data.fee;
         from.reserve = isSorted ? coinXReserve : coinYReserve;
         to.reserve = isSorted ? coinYReserve : coinXReserve;
-
       } catch (e) {
         from.reserve = 0;
         to.reserve = 0;
@@ -180,15 +170,12 @@ export const useSwapStore = defineStore('swapStore', () => {
           interactiveToken: mode,
           curveType: getShortCurveFromFull(curve.value) as 'stable' | 'uncorrelated',
           amount: mode === 'from' ? from.amount! : to.amount!,
-          version: version.value as unknown as TVersionType
+          version: version.value as unknown as TVersionType,
         });
-      } catch(_e) {
-      }
+      } catch (_e) {}
 
       convertError.value =
-        to.amount && to.reserve < to.amount
-          ? 'Insufficient funds in Liquidity Pool'
-          : undefined;
+        to.amount && to.reserve < to.amount ? 'Insufficient funds in Liquidity Pool' : undefined;
       if (d(rate).lessThanOrEqualTo(0) || !isFinite(Number(rate))) {
         if (!silent) {
           isUpdatingRate.value = false;
@@ -203,24 +190,15 @@ export const useSwapStore = defineStore('swapStore', () => {
         from.amount = +Number(Number(rate).toFixed(0));
       }
 
-      const toDec = d(to.amount).div(
-        decimalsMultiplier(tokensStore.tokens[to.token].decimals),
-      );
-      const fromDec = d(from.amount).div(
-        decimalsMultiplier(tokensStore.tokens[from.token].decimals),
-      );
+      const toDec = d(to.amount).div(decimalsMultiplier(tokensStore.tokens[to.token].decimals));
+      const fromDec = d(from.amount).div(decimalsMultiplier(tokensStore.tokens[from.token].decimals));
 
       convertRate.value = +Number(
-        toDec
-          .div(fromDec)
-          .mul(decimalsMultiplier(tokensStore.tokens[to.token].decimals))
-          .toFixed(0),
+        toDec.div(fromDec).mul(decimalsMultiplier(tokensStore.tokens[to.token].decimals)).toFixed(0),
       );
       convertFee.value = (fee.value * 100) / DENOMINATOR;
       convertFeeAmount.value =
-        from?.amount && from.amount > 0
-          ? from.amount * convertFee.value * 0.01
-          : 0;
+        from?.amount && from.amount > 0 ? from.amount * convertFee.value * 0.01 : 0;
       if (!silent) {
         isUpdatingRate.value = false;
       }
@@ -232,33 +210,20 @@ export const useSwapStore = defineStore('swapStore', () => {
 
   async function check() {
     if (!from?.token || !to?.token || !curve.value) return;
-    await poolExistence.check({
-      fromCoin: from.token,
-      toCoin: to.token,
-      curve: getShortCurveFromFull(curve.value) as 'stable' | 'uncorrelated',
-      version: version.value as unknown as TVersionType,
-    });
+
+    await poolExistence.check(
+      {
+        fromCoin: from.token,
+        toCoin: to.token,
+        curve: curve.value,
+      },
+      version.value,
+    );
   }
 
   watchDebounced(
-    () => [
-      version,
-      from.amount,
-      from.reserve,
-      from.token,
-      to.amount,
-      to.reserve,
-      to.token,
-      curve
-    ],
-    async (_newState,_oldState) => {
-      // if we switch tokens to a new value
-      if (
-        predefinedCurve.value !== false &&
-        predefinedCurve.value === getCurve('uncorrelated', version.value)
-      ) {
-        version.value = VERSION_0;
-      }
+    () => [version, from.amount, from.reserve, from.token, to.amount, to.reserve, to.token, curve],
+    async (_changed) => {
       await check();
       refetchRates(false);
     },
@@ -275,33 +240,43 @@ export const useSwapStore = defineStore('swapStore', () => {
     const slippagePercent = slippage.value * MULTIPLY;
 
     if (lastInteractiveField.value === 'from' && to.amount !== undefined) {
-      return version.value === VERSION_0_5 ||
-      curve.value === getCurve('uncorrelated', version.value)
+      return version.value === VERSION_0_5 || curve.value === getCurve('uncorrelated', version.value)
         ? to.amount - (to.amount * slippagePercent) / MULTIPLY
         : to.amount - 1;
-    } else if (
-      lastInteractiveField.value === 'to' &&
-      from.amount !== undefined
-    ) {
-      return version.value === VERSION_0_5 ||
-      curve.value === getCurve('uncorrelated', version.value)
+    } else if (lastInteractiveField.value === 'to' && from.amount !== undefined) {
+      return version.value === VERSION_0_5 || curve.value === getCurve('uncorrelated', version.value)
         ? from.amount + (from.amount * slippagePercent) / MULTIPLY
         : from.amount;
     }
     return 0;
   });
 
+  /**
+   * Pool is absence
+   */
   const isPoolAbsence = computed(
-    () =>
+    (): boolean =>
       !!from.token &&
       !!to.token &&
-      !poolExistence.isFetching.value &&
-      !poolExistence.poolExists.value,
+      !poolExistence.isFetching(
+        {
+          fromCoin: from.token,
+          toCoin: to.token,
+          curve: curve.value ?? '',
+        },
+        version.value,
+      ) &&
+      !poolExistence.poolExists(
+        {
+          fromCoin: from.token,
+          toCoin: to.token,
+          curve: curve.value ?? '',
+        },
+        version.value,
+      ),
   );
 
-  const isBusy = computed(
-    () => poolExistence.isFetching || isUpdatingRate.value,
-  );
+  const isBusy = computed(() => poolExistence.isFetching || isUpdatingRate.value);
 
   const priceImpact = computed(() => {
     if (!from?.amount || !from.reserve || !to.reserve) return 0;
@@ -320,14 +295,11 @@ export const useSwapStore = defineStore('swapStore', () => {
     maximumFractionDigits: 2,
   });
 
-  const priceImpactFormatted = computed(() =>
-    formatter.format(priceImpact.value),
-  );
+  const priceImpactFormatted = computed(() => formatter.format(priceImpact.value));
 
   const priceImpactState = computed(() => {
     if (+priceImpactFormatted.value <= 10) return 'normal';
-    if (+priceImpactFormatted.value >= 10 && +priceImpactFormatted.value < 20)
-      return 'warning';
+    if (+priceImpactFormatted.value >= 10 && +priceImpactFormatted.value < 20) return 'warning';
     return 'alert';
   });
 

--- a/src/store/useSwapStore.ts
+++ b/src/store/useSwapStore.ts
@@ -240,11 +240,11 @@ export const useSwapStore = defineStore('swapStore', () => {
     const slippagePercent = slippage.value * MULTIPLY;
 
     if (lastInteractiveField.value === 'from' && to.amount !== undefined) {
-      return version.value === VERSION_0_5 || curve.value === getCurve('uncorrelated', version.value)
+      return version.value === VERSION_0_5 || curve.value === getCurve('unstable', version.value)
         ? to.amount - (to.amount * slippagePercent) / MULTIPLY
         : to.amount - 1;
     } else if (lastInteractiveField.value === 'to' && from.amount !== undefined) {
-      return version.value === VERSION_0_5 || curve.value === getCurve('uncorrelated', version.value)
+      return version.value === VERSION_0_5 || curve.value === getCurve('unstable', version.value)
         ? from.amount + (from.amount * slippagePercent) / MULTIPLY
         : from.amount;
     }

--- a/src/styles/components/curveSwitch.scss
+++ b/src/styles/components/curveSwitch.scss
@@ -1,0 +1,50 @@
+.stable-switch-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 8px;
+    gap: 4px;
+    background: #272742;
+    border-radius: 12px;
+    width: 100%;
+
+    &__switch {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        padding: 4px 10px;
+        gap: 8px;
+        width: 100%;
+        cursor: pointer;
+        transition: all 0.5s linear;
+
+        &.busy {
+            cursor: default;
+            opacity: 0.5;
+        }
+
+        &[disabled='true'] {
+            opacity: 0.5;
+        }
+
+        p {
+            font-family: var(--font-family);
+            font-style: normal;
+            font-weight: 500;
+            font-size: 16px;
+            line-height: 120%;
+            color: #ffffff;
+            margin-block: 0rem;
+        }
+
+        i {
+            opacity: 0.5;
+        }
+    }
+}
+
+.isSelected {
+    background: #4d4d70;
+    border-radius: 12px;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -16,4 +16,5 @@
 @import '../components/ButtonToken/buttonToken';
 @import '../components/FrontrunOverlay/frontRunOverlay';
 @import '../components/PriceImpactWarningDialog/PriceImpactWarningDialog';
+@import '../styles//components/curveSwitch.scss';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ import {
   WalletName,
 } from '@pontem/aptos-wallet-adapter';
 
-import { VERSION_0, VERSION_0_5 } from "@/constants/constants";
+import { VERSION_0, VERSION_0_5 } from '@/constants/constants';
 
 export type AptosCoinInfoResource = {
   decimals: string;
@@ -77,9 +77,7 @@ export interface IPoolExist {
   fromCoin: string;
   toCoin: string;
   curve: string;
-  version: TVersionType;
 }
 
-export type TStatusTransaction = "success" | "pending" | "error" | "rejected";
-
+export type TStatusTransaction = 'success' | 'pending' | 'error' | 'rejected';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,7 +42,9 @@ export interface IWallet {
   options?: any;
 }
 
-export type TCurveType = 'uncorrelated' | 'stable' | 'selectable';
+// export type TCurveType = 'uncorrelated' | 'stable' | 'selectable';
+
+export type TCurveType = 'unstable' | 'stable';
 
 export type TStableSwapType = 'normal' | 'high';
 

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -69,7 +69,7 @@ export function getCurve(type: TCurveType, contract?: number): string {
     }
     return CURVE_UNCORRELATED_V05;
   }
-  if (type === 'uncorrelated') {
+  if (type === 'unstable') {
     return CURVE_UNCORRELATED;
   }
   return CURVE_STABLE;
@@ -81,7 +81,7 @@ export function getCurve(type: TCurveType, contract?: number): string {
  * @param type full type of curve
  * @returns short curve name
  */
-export function getShortCurveFromFull(type: string): TCurveType {
+export function getShortCurveFromFull(type: string): 'stable' | 'uncorrelated' {
   if (type === CURVE_STABLE || type === CURVE_STABLE_V05) return 'stable';
   if (type === CURVE_UNCORRELATED || type === CURVE_UNCORRELATED_V05) return 'uncorrelated';
   throw new Error('Wrong curve type passed');

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -16,6 +16,7 @@ const TITLES: Record<string, string> = {
   wormhole: 'Wormhole',
   chainx: 'ChainX',
   celer: 'Celer',
+  multichain: 'Multichain',
 };
 
 export function titleForToken(token: IPersistedToken) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,10 +307,10 @@
     react-dom "^18.X.X || 17.X.X"
     vue "3.2.40"
 
-"@pontem/coins-registry@2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@pontem/coins-registry/-/coins-registry-2.1.8.tgz#730e807d83da00972aadc2b6d93aae5f3455c938"
-  integrity sha512-EdFgaS8Pw7MJU2slLC9N5G2UH/gEgLTixT5Ad+BE1y+fqYyxyPLd/xfpbNwSZGwz+gAO3sNVjehoFZZhvbEnHA==
+"@pontem/coins-registry@2.1.19":
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/@pontem/coins-registry/-/coins-registry-2.1.19.tgz#b615c72ae9477a6559ddb41102d25b0943f9683e"
+  integrity sha512-OMQXIRvZaOzka4pg2afrNocP4xyFz3iXyL/tOpysBIGZeIF+GCR9lt+zcuXAFleNJWOToE9LLksFNVDQC6atGA==
 
 "@pontem/liquidswap-sdk@0.6.1":
   version "0.6.1"


### PR DESCRIPTION
Task from LS that was added to the widget: https://pontem-network.atlassian.net/browse/LS-1231
Description of the swap flow: https://www.notion.so/walletsofwings/Contract-version-v0-5-7264bd3f7cfa4c28a82996de9248c61c
Thread: https://pontem-org.slack.com/archives/C03RW4ECLNB/p1692315853327849

* Added logic of disabling the selection of the curve and version depending on the existence of the pool.
* Coins-registry has been updated [to 2.1.19](https://github.com/pontem-network/liquidswap-widget/commit/fdc99949aeee326c230386d0c9adac088c89c5ca)
* Added support for the token provider "multichain"
* Replaced "uncorrelated" with "unstable" according to LS in TCurveType
* Updated hover style of the "Select token" button (before that, when hovering, the button turned contrasting purple. Now it's green)


The logic of work:
1. When choosing a pair, a check is made for the existence of a pool in contracts versions 0 and 0.5 (with curves)
2. Based on the check, the "CurveSwitch" and "ContractSwitch" components assume the "disabled" or "enabled" state
3. The expected behavior can be verified through comparison with LS:
 3.1 The uncorrelated pool known to us. Only swap version 0 is available ![image](https://github.com/pontem-network/liquidswap-widget/assets/30174295/e17f4ed3-24da-46dc-b2e5-3a5b8dedc244)
 3.2 A stable pool is known to us. The curve is stable, a version switch is available. ![image](https://github.com/pontem-network/liquidswap-widget/assets/30174295/c6c84c5b-d3b6-4ce0-a3fd-04113cd941ad)
 3.3. The pool is unknown to us - curve and version switches are available, and they may be in the "disabled" state if a pool with such a configuration does not exist. 
![image](https://github.com/pontem-network/liquidswap-widget/assets/30174295/e09785c6-c6b3-499a-b7b8-cf828df1c06f)


